### PR TITLE
Escape dollar signs used in DispositionType text

### DIFF
--- a/as2-lib/src/main/java/com/helger/as2lib/processor/receiver/net/AS2ReceiverHandler.java
+++ b/as2-lib/src/main/java/com/helger/as2lib/processor/receiver/net/AS2ReceiverHandler.java
@@ -445,7 +445,7 @@ public class AS2ReceiverHandler extends AbstractReceiverHandler
       catch (final OpenAS2Exception ex)
       {
         throw new DispositionException (DispositionType.createError ("unexpected-processing-error"),
-                                        AbstractActiveNetModule.DISP_VALIDATION_FAILED + "\n" + StackTraceHelper.getStackAsString (ex),
+                                        AbstractActiveNetModule.DISP_VALIDATION_FAILED + "\n" + StackTraceHelper.getStackAsString (ex).replace ("$", "$$"),
                                         ex);
       }
 
@@ -461,7 +461,7 @@ public class AS2ReceiverHandler extends AbstractReceiverHandler
       catch (final OpenAS2Exception ex)
       {
         throw new DispositionException (DispositionType.createError ("unexpected-processing-error"),
-                                        AbstractActiveNetModule.DISP_STORAGE_FAILED + "\n" + ex.getMessage (),
+                                        AbstractActiveNetModule.DISP_STORAGE_FAILED + "\n" + ex.getMessage ().replace ("$", "$$"),
                                         ex);
       }
 
@@ -477,7 +477,7 @@ public class AS2ReceiverHandler extends AbstractReceiverHandler
       catch (final OpenAS2Exception ex)
       {
         throw new DispositionException (DispositionType.createError ("unexpected-processing-error"),
-                                        AbstractActiveNetModule.DISP_VALIDATION_FAILED + "\n" + StackTraceHelper.getStackAsString (ex),
+                                        AbstractActiveNetModule.DISP_VALIDATION_FAILED + "\n" + StackTraceHelper.getStackAsString (ex).replace ("$", "$$"),
                                         ex);
       }
 


### PR DESCRIPTION
Exceptions and exception stack traces can contain literal dollar signs,
such as names of anonymous inner classes, that get incorrectly expanded
by AbstractParameterParser.format.

This causes as2lib to fail and not send a proper MDN back in certain
conditions.