### PR TITLE
Fix MIC mismatch error when server users largeFile

### DIFF
--- a/as2-lib/src/main/java/com/helger/as2lib/processor/receiver/net/AS2ReceiverHandler.java
+++ b/as2-lib/src/main/java/com/helger/as2lib/processor/receiver/net/AS2ReceiverHandler.java
@@ -581,16 +581,6 @@ public class AS2ReceiverHandler extends AbstractReceiverHandler
         if (aMsg.isRequestingMDN ())
         {
           // Transmit a success MDN if requested
-          if (aMsg.attrs ().getAsBoolean (ATTR_LARGE_FILE_SUPPORT_ON))
-          {
-            // if large file support is on, the message does not hold the actual
-            // data. in order to get the data for the MDN, a new message that
-            // will take the data from the file that was written should be used
-            final String sStoredFileName = aMsg.attrs ().getAsString (ATTR_STORED_FILE_NAME);
-            final FileDataSource aFileDataSource = new FileDataSource (sStoredFileName);
-            final DataHandler aDataFromFile = new DataHandler (aFileDataSource);
-            aMsg.getData ().setDataHandler (aDataFromFile);
-          }
           sendMDN (sClientInfo,
                    aResponseHandler,
                    aMsg,


### PR DESCRIPTION
Hi Philip,
This is a fix to issue "When using largefileon=true MIC isn't matched when using sign,encrypt and compress #25" from as2-server. The wrong code used a different dataHandler to compute the MIC, but the different handler used different headers, which caused the MIC to be different.