### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ Csp6cWSq7YCHomfEPfZDuL/5kdId/PQNenN49tX1lQ+kbf5MC/4+hDBQI/Pqf8gANwWOdHqQ9tYibxbx
 k3n/auO5/uY/wmRrWwhSiFLmxjGQozkwXoVhdGGKb6zjYMzainBlF0="
 
 install:
-#  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -U -P jdeps
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -U
+#  - mvn -T 1C install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -U -P jdeps
+  - mvn -T 1C install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -U
 
 cache:
   directories:
@@ -40,16 +40,16 @@ jobs:
     - stage: test
       jdk: openjdk8
       script:
-        - mvn test -B
+        - mvn -T 1C test -B
       after_success:
-        - mvn deploy --settings travis-settings.xml -DskipTests=true -B -P travis-deploy
+        - mvn -T 1C deploy --settings travis-settings.xml -DskipTests=true -B -P travis-deploy
     - stage: test
       jdk: openjdk11
       script:
-        - mvn test -B -P coverage sonar:sonar
+        - mvn -T 1C test -B -P coverage sonar:sonar
       after_success:
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       jdk: openjdk14
       script:
-        - mvn test -B
+        - mvn -T 1C test -B

--- a/as2-demo-spring-boot/pom.xml
+++ b/as2-demo-spring-boot/pom.xml
@@ -41,26 +41,16 @@
   </licenses>
 
   <dependencies>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
+    
 
     <dependency>
       <groupId>com.helger.as2</groupId>
       <artifactId>as2-servlet</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-    </dependency>
+    
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
+    
   </dependencies>
 
   <build>

--- a/as2-demo-webapp/pom.xml
+++ b/as2-demo-webapp/pom.xml
@@ -43,21 +43,11 @@
       <groupId>com.helger.as2</groupId>
       <artifactId>as2-servlet</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
+    
 
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-    </dependency>
+    
 
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
+    
     
     <dependency>
       <groupId>junit</groupId>

--- a/as2-lib/pom.xml
+++ b/as2-lib/pom.xml
@@ -85,11 +85,7 @@
       <artifactId>httpclient</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
+    
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/as2-partnership-mongodb/pom.xml
+++ b/as2-partnership-mongodb/pom.xml
@@ -67,11 +67,7 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
+    
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>

--- a/as2-server/pom.xml
+++ b/as2-server/pom.xml
@@ -61,22 +61,10 @@
       <artifactId>as2-lib</artifactId>
     </dependency>
     
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jul-to-slf4j</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-    </dependency>
+    
+    
+    
+    
     
     <dependency>
       <groupId>junit</groupId>

--- a/as2-servlet/pom.xml
+++ b/as2-servlet/pom.xml
@@ -59,11 +59,7 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
+    
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION

[Parallel builds in Maven 3](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3) Maven 3.x has the capability to perform parallel builds.

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
as2-lib-parent-pom
as2-lib
{groupId='org.slf4j', artifactId='slf4j-simple', version='1.7.30', scope='test'}
as2-partnership-mongodb
{groupId='org.slf4j', artifactId='slf4j-simple', version='1.7.30', scope='test'}
as2-servlet
{groupId='org.slf4j', artifactId='slf4j-simple', version='1.7.30', scope='test'}
as2-demo-webapp
{groupId='org.slf4j', artifactId='slf4j-simple', version='1.7.30', scope='compile'}
{groupId='com.sun.xml.bind', artifactId='jaxb-impl', version='2.3.3', scope='compile'}
{groupId='javax.servlet', artifactId='javax.servlet-api', version='3.1.0', scope='provided'}
as2-server
{groupId='org.slf4j', artifactId='jul-to-slf4j', version='1.7.30', scope='compile'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core', version='2.14.1', scope='compile'}
{groupId='org.apache.logging.log4j', artifactId='log4j-slf4j-impl', version='2.14.1', scope='compile'}
{groupId='com.sun.xml.bind', artifactId='jaxb-impl', version='2.3.3', scope='compile'}
as2-demo-spring-boot
{groupId='org.springframework.boot', artifactId='spring-boot-starter-web', version='2.5.3', scope='compile'}
{groupId='com.sun.xml.bind', artifactId='jaxb-impl', version='2.3.3', scope='compile'}
{groupId='org.springframework.boot', artifactId='spring-boot-starter-test', version='2.5.3', scope='test'}
{groupId='org.slf4j', artifactId='slf4j-api', version='1.7.30', scope='compile'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
