### PR TITLE
Fix NPE in createSyncMDN when IncomingMIC is null

### DIFF
--- a/phase2-lib/src/main/java/com/helger/phase2/util/AS2Helper.java
+++ b/phase2-lib/src/main/java/com/helger/phase2/util/AS2Helper.java
@@ -298,7 +298,8 @@ public final class AS2Helper
    * @param aMsg
    *        The source AS2 message for which the MDN is to be created. May not be <code>null</code>.
    * @param aIncomingMIC
-   *        The MIC of the incoming message. May not be <code>null</code>.
+   *        The MIC of the incoming message. May be <code>null</code> for unsigned messages or when
+   *        an error occurs before MIC computation.
    * @param aDisposition
    *        The disposition - either success or error. May not be <code>null</code>.
    * @param sText
@@ -316,7 +317,6 @@ public final class AS2Helper
   {
     ValueEnforcer.notNull (aSession, "AS2Session");
     ValueEnforcer.notNull (aMsg, "AS2Message");
-    ValueEnforcer.notNull (aIncomingMIC, "IncomingMIC");
     ValueEnforcer.notNull (aDisposition, "Disposition");
     ValueEnforcer.notNull (sText, "Text");
 

--- a/phase2-lib/src/test/java/com/helger/phase2/util/AS2HelperTest.java
+++ b/phase2-lib/src/test/java/com/helger/phase2/util/AS2HelperTest.java
@@ -1,0 +1,85 @@
+/*
+ * The FreeBSD Copyright
+ * Copyright 1994-2008 The FreeBSD Project. All rights reserved.
+ * Copyright (C) 2013-2026 Philip Helger philip[at]helger[dot]com
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other copies of the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE FREEBSD PROJECT ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE FREEBSD PROJECT OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * official policies, either expressed or implied, of the FreeBSD Project.
+ */
+package com.helger.phase2.util;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.helger.http.CHttpHeader;
+import com.helger.phase2.disposition.DispositionType;
+import com.helger.phase2.message.AS2Message;
+import com.helger.phase2.message.AS2MessageMDN;
+import com.helger.phase2.message.IMessageMDN;
+import com.helger.phase2.partner.Partnership;
+import com.helger.phase2.partner.SelfFillingPartnershipFactory;
+import com.helger.phase2.session.AS2Session;
+
+/**
+ * Test class for class {@link AS2Helper}
+ */
+public final class AS2HelperTest
+{
+  /**
+   * Regression test: createSyncMDN must not throw when aIncomingMIC is null.
+   * MIC may legitimately be null for unsigned messages or when an error occurs
+   * before MIC computation (AS2DispositionException path).
+   */
+  @Test
+  public void testCreateSyncMDNWithNullMIC () throws Exception
+  {
+    final AS2Session aSession = new AS2Session ();
+    aSession.setPartnershipFactory (new SelfFillingPartnershipFactory ());
+
+    final Partnership aPartnership = new Partnership ("test");
+    aPartnership.setSenderAS2ID ("sender");
+    aPartnership.setReceiverAS2ID ("receiver");
+
+    final AS2Message aMsg = new AS2Message ();
+    aMsg.setPartnership (aPartnership);
+    aMsg.headers ().setHeader (CHttpHeader.AS2_TO, "sender");
+    aMsg.headers ().setHeader (CHttpHeader.MESSAGE_ID, "<test@example>");
+
+    // Must not throw NPE
+    final IMessageMDN aMDN = AS2Helper.createSyncMDN (aSession,
+                                                       aMsg,
+                                                       null,
+                                                       DispositionType.createSuccess (),
+                                                       "Test MDN");
+    assertNotNull (aMDN);
+    // No MIC algorithm configured and no Disposition-Notification-Options header
+    // -> MDNA_MIC attribute must be absent
+    assertNull (aMDN.attrs ().getAsString (AS2MessageMDN.MDNA_MIC));
+  }
+}


### PR DESCRIPTION
## Problem

`AS2Helper.createSyncMDN()` declares `aIncomingMIC` as `@Nullable` (line 313) but enforces non-null via `ValueEnforcer.notNull` (line 319), causing a `NullPointerException` in two legitimate scenarios:

1. **Error MDN path** — in `AS2ReceiverHandler`, `aIncomingMIC` is `null` when an `AS2DispositionException` is thrown before MIC computation (line 623). The catch block at line 756 calls `sendSyncMDN` with `null`, making it impossible to send error MDNs for early failures (decryption, decompression, etc.)

2. **Unsigned messages** — `createMICOnReception()` explicitly returns `null` when no signing algorithm is configured (line 265). This is valid per RFC 4130: `Received-Content-MIC` is only required when the sender requested a signed receipt.

The null-safe fallback at lines 379-382 (with its own comment **"MIC may be null when called from the Exception handler of receiving"**) was already handling this correctly, but was unreachable due to the enforcer above it.

## Fix

- Remove `ValueEnforcer.notNull(aIncomingMIC, "IncomingMIC")` in `AS2Helper.java`
- Update `@param aIncomingMIC` Javadoc accordingly
- Add regression test `AS2HelperTest.testCreateSyncMDNWithNullMIC()`